### PR TITLE
Added npm scripts to readme for easy copy-pasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Installation does not assume any previous packages having been installed. Thus t
 
 `"eslint-config-vocovo": "https://github.com/vocovo/eslint-config-vocovo",`
 
+3. Add these lines to your npm `scripts` section:
+
+```
+"lint": "eslint --ext .js src",
+"lint:ci": "eslint -f summary --ext .js src",
+```
+
 ### For formatting independent of ESLint
 
 If you choose to run prettier on its own, e.g as part of a git hook with `pretty-quick`, you will need to give prettier a config. Typically this is done with a `.prettierrc` file into which you add rules.


### PR DESCRIPTION
I added the following to the readme as a bullet point '3.':

```
"lint": "eslint --ext .js src",
"lint:ci": "eslint -f summary --ext .js src",
```

Look okay/useful?