### PR TITLE
Feature/add eslint rc to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Installation does not assume any previous packages having been installed. Thus t
 
 `"eslint-config-vocovo": "https://github.com/vocovo/eslint-config-vocovo",`
 
+and run `yarn` to install it
+
 3. Add these lines to your npm `scripts` section:
 
 ```

--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ Installation does not assume any previous packages having been installed. Thus t
 "lint:ci": "eslint -f summary --ext .js src",
 ```
 
+4. Add the following `.eslintrc` to your project root
+
+```
+{
+  "extends": ["vocovo"],
+  "env": {
+    "mocha": true
+  }
+}
+```
+
 ### For formatting independent of ESLint
 
 If you choose to run prettier on its own, e.g as part of a git hook with `pretty-quick`, you will need to give prettier a config. Typically this is done with a `.prettierrc` file into which you add rules.


### PR DESCRIPTION
- Added instruction to run `yarn` to install `eslint-config-vocovo`
- Added the required `.eslintrc` to the readme as step 4