### PR TITLE
Feature/show warning comments as warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     ],
     "react/jsx-no-bind": 0,
     "standard/no-callback-literal": 0,
+    "no-warning-comments": "warn",
     "prettier/prettier": [
       "error",
       prettierrc

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+### This Pull Request is associated with card(s) URL(s):
+
+...
+
+### Brief summary of the problem/need for this work:
+
+...
+
+### Detail of how this Pull Request solves the problem/need:
+
+...
+
+### Notes to reviewers:
+
+> e.g:
+>
+> - This is pull request part X of Y, I'm splitting it this way because ...
+> - Please pay special attention to ...
+> - I'd like confirmation that my code is solid on line ... ?
+> - Does anyone know another place I've forgotten to ... ?
+> - Is there a better way of doing ... ?
+> - Have I missed something only you know of?


### PR DESCRIPTION
### This Pull Request is associated with card(s) URL(s):
No card
...

### Brief summary of the problem/need for this work:
The codebase contains `TODO` and `FIXME` comments. These are considered "warnings" to other developers and undesirable. It would be good to highlight them to devs without causing lint errors.
...

### Detail of how this Pull Request solves the problem/need:
Have set `no-warning-comments` role to `warn`, which will highlight it in the IDE but won't cause linting to exit with an error code.