### PR TITLE
Publish via NPM

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-//npm.pkg.github.com/:_authToken=${NPM_GITHUB_TOKEN}
-registry=https://npm.pkg.github.com/vocovo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vocovo/eslint-config-vocovo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A reasonable lint standard for VoCoVo javascript projects. Uses ESLint and Prettier",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,5 @@
     "prettier": "^1.18.2",
     "prettier-config-standard": "^1.0.1",
     "pretty-quick": "^1.11.1"
-  },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
   }
 }


### PR DESCRIPTION
### This Pull Request is associated with card(s) URL(s):
 
n/a

### Brief summary of the problem/need for this work:

Moving to publish as a public NPM package for simplicity across Vocovo projects

### Detail of how this Pull Request solves the problem/need:

Removes the publish config for Github. Also bumps the version, since we are changing the package.json.
Also removes the .npmrc file which seems unnecessary(?)

### Notes to reviewers:

I will create a tag for 1.0.1 and publish on NPM once this is merged.
