### PR TITLE
Remove scope from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@vocovo/eslint-config-vocovo",
+  "name": "eslint-config-vocovo",
   "version": "1.0.1",
   "description": "A reasonable lint standard for VoCoVo javascript projects. Uses ESLint and Prettier",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vocovo",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A reasonable lint standard for VoCoVo javascript projects. Uses ESLint and Prettier",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### This Pull Request is associated with card(s) URL(s):

n/a

### Brief summary of the problem/need for this work:

The `@vocovo` scope prevents this package being used in both cloud and controller repos, because these repos use different registries for the same scope.

### Detail of how this Pull Request solves the problem/need:

Removing this scope means that this package can be used by all repos, and does not add any complexity since this is a public package anyway.

Eventually we will migrate all our NPM packages to Github, but for now this will resolve the issue.

### Notes to reviewers:

I have bumped the version again to prevent confusion.
I will publish this once it's merged
